### PR TITLE
NAS-139567 / 26.0.0-BETA.1 / Skip building dns-lexicon from source

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -23,6 +23,7 @@ SKIP_NO_BINARY = {
     "certbot-dns-google",  # Depends on cryptography
     "certbot-dns-ovh",  # Depends on cryptography
     "cffi",  # Use Debian's python3-cffi package
+    "dns-lexicon",  # Depends on cryptography
 }
 PIP_TO_DEBIAN_MAPPING = {
     "attrs": "python3-attr",


### PR DESCRIPTION
This commit fixes build failure caused by maturin requiring Rust when building dns-lexicon's cryptography dependency from source.