### PR TITLE
NAS-137681 / 26.0.0-BETA.1 / Add constraint for cryptography

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,2 @@
-# All constraints now handled by Debian packages
+# Constrain to Debian Trixie versions to avoid phantom dependency issues
+cryptography==43.0.0  # Debian Trixie has 43.0.0-3


### PR DESCRIPTION
This commit fixes phantom cffi>=2.0.0 dependency caused by pip resolving to PyPI's latest cryptography (46.x) instead of Debian's version (43.0.0) which only requires cffi>=1.12.