### PR TITLE
NAS-139572 / 26.0.0-BETA.1 / Fix duplicate dependencies in generated debian/control

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -145,7 +145,7 @@ def generate_control():
                 else:
                     depends.append(dependency)
 
-        depends.sort()
+        depends = sorted(set(depends))
 
         control += "\n" + textwrap.dedent(f"""\
             Package: {package_name}


### PR DESCRIPTION
This commit fixes an issue where pip can output the same dependency multiple times during resolution:
```
  Collecting PyOpenSSL>=25.0.0 (from acme->certbot-dns-digitalocean)
  Collecting PyOpenSSL>=25.0.0 (from acme->certbot-dns-digitalocean)
```
generate.py parsed all "Collecting" lines without deduplication, resulting in duplicate entries in debian/control:
```
  Depends: ..., python3-openssl (>= 25.0.0), python3-openssl (>= 25.0.0), ...
```